### PR TITLE
feat(divider): add Divider component

### DIFF
--- a/apps/storybook/src/assets/css/divider.storybook.css
+++ b/apps/storybook/src/assets/css/divider.storybook.css
@@ -1,0 +1,5 @@
+.divider--froglet {
+  --divider-border-color: var(--color-border);
+  --divider-border-width: 1px;
+  --divider-border-style: solid;
+}

--- a/apps/storybook/src/stories/Divider.stories.tsx
+++ b/apps/storybook/src/stories/Divider.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Divider } from "@froglet/ui";
+import "../assets/css/divider.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Divider/README.md?raw";
+
+// Strip the leading `# Divider` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+const meta = {
+  title: "Divider",
+  component: Divider,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The unstyled Divider. No CSS custom properties are set — renders a `currentColor` horizontal line. Apply a modifier class to theme it.",
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  args: {
+    className: "divider--froglet",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Themed with the Froglet neutral border color.
+
+\`\`\`css
+.divider--froglet {
+  --divider-border-color: #d1d5db;
+  --divider-border-width: 1px;
+  --divider-border-style: solid;
+}
+\`\`\``,
+      },
+    },
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+    className: "divider--froglet",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: "flex", height: "4rem", alignItems: "center" }}>
+        <span>Left</span>
+        <Story />
+        <span>Right</span>
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Vertical orientation. Wrapped in a flex row so the divider has space to render. `align-self: stretch` in the component CSS fills the cross-axis automatically.",
+      },
+    },
+  },
+};

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -179,6 +179,16 @@ All interactive components share a consistent shape language.
 }
 ```
 
+### Divider
+
+```css
+.divider--froglet {
+  --divider-border-color: #d1d5db;
+  --divider-border-width: 1px;
+  --divider-border-style: solid;
+}
+```
+
 ### Input
 
 ```css

--- a/packages/froglet-ui/src/Divider/Divider.test.tsx
+++ b/packages/froglet-ui/src/Divider/Divider.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Divider } from "./Divider";
+
+describe("Divider", () => {
+  it("renders", () => {
+    render(<Divider />);
+    expect(screen.getByRole("separator")).toBeDefined();
+  });
+
+  it("applies className", () => {
+    render(<Divider className="my-divider" />);
+    expect(screen.getByRole("separator").classList.contains("my-divider")).toBe(
+      true,
+    );
+  });
+
+  it("adds vertical class when orientation is vertical", () => {
+    render(<Divider orientation="vertical" />);
+    expect(
+      screen.getByRole("separator").classList.contains("divider--vertical"),
+    ).toBe(true);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLHRElement>();
+    render(<Divider ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLHRElement);
+  });
+});

--- a/packages/froglet-ui/src/Divider/Divider.tsx
+++ b/packages/froglet-ui/src/Divider/Divider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { HTMLAttributes } from "react";
+import classNames from "classnames";
+import "./divider.css";
+
+export interface DividerProps extends HTMLAttributes<HTMLHRElement> {
+  /** Visual and semantic orientation. Sets `.divider--vertical` and `aria-orientation`. */
+  orientation?: "horizontal" | "vertical";
+  /** Additional CSS classes. Use to apply a token block. */
+  className?: string;
+  /** Ref forwarded to the underlying `<hr>` element. */
+  ref?: React.Ref<HTMLHRElement>;
+}
+
+/** A brandless separator element styled entirely through CSS custom properties. */
+export const Divider = ({
+  orientation = "horizontal",
+  className,
+  ref,
+  ...props
+}: DividerProps) => {
+  return (
+    <hr
+      ref={ref}
+      aria-orientation={orientation === "vertical" ? "vertical" : undefined}
+      className={classNames(
+        "divider",
+        { "divider--vertical": orientation === "vertical" },
+        className,
+      )}
+      {...props}
+    />
+  );
+};

--- a/packages/froglet-ui/src/Divider/README.md
+++ b/packages/froglet-ui/src/Divider/README.md
@@ -1,0 +1,61 @@
+# Divider
+
+A brandless separator element. All visual styling is driven by CSS custom properties — no color defaults are applied, so the component renders with inherited text color until tokens are provided.
+
+## Usage
+
+```tsx
+import { Divider } from "@froglet/ui";
+
+<Divider />;
+```
+
+Accepts all standard global HTML attributes: `id`, `style`, `aria-*`, and more.
+
+### Vertical
+
+```tsx
+<div style={{ display: "flex", height: "4rem", alignItems: "center" }}>
+  <span>Left</span>
+  <Divider orientation="vertical" />
+  <span>Right</span>
+</div>
+```
+
+## Props
+
+| Prop          | Type                            | Default        | Description                                                                                                            |
+| ------------- | ------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `orientation` | `"horizontal" \| "vertical"`    | `"horizontal"` | Visual and semantic orientation. Adds `.divider--vertical` class and sets `aria-orientation="vertical"` when vertical. |
+| `className`   | `string`                        | —              | Additional CSS classes. Use to apply a token block (see Variants).                                                     |
+| `ref`         | `React.Ref<HTMLHRElement>`      | —              | Forwarded to the underlying `<hr>` element.                                                                            |
+| `...props`    | `HTMLAttributes<HTMLHRElement>` | —              | All standard global HTML attributes.                                                                                   |
+
+## CSS Custom Properties
+
+| Token                    | Default  | Description                                                   |
+| ------------------------ | -------- | ------------------------------------------------------------- |
+| `--divider-border-width` | `1px`    | Line thickness                                                |
+| `--divider-border-style` | `solid`  | Line style (`solid`, `dashed`, `dotted`, etc.)                |
+| `--divider-border-color` | —        | Line color. No default; renders as `currentColor` when unset. |
+| `--divider-margin`       | `1rem 0` | Surrounding space (horizontal). Use `0 1rem` for vertical.    |
+| `--divider-width`        | `100%`   | Width of the horizontal divider                               |
+| `--divider-height`       | `100%`   | Height of the vertical divider                                |
+
+Color tokens with no default (—) are intentionally bare: apply a modifier class to provide colors.
+
+## Variants
+
+Variants are not built into the component. Apply a CSS class that sets the appropriate tokens for your brand.
+
+```tsx
+<Divider className="divider--brand" />
+```
+
+See the [Froglet Style Guide](../../../../docs/style-guide.md) for a reference implementation, or [Modifier Classes](../../../../docs/modifiers.md) for the general pattern.
+
+## Accessibility
+
+- The `<hr>` element has an implicit ARIA `role="separator"` with `aria-orientation="horizontal"`.
+- When `orientation="vertical"`, `aria-orientation="vertical"` is set explicitly.
+- No interactive focus ring is needed — `<hr>` is not focusable.

--- a/packages/froglet-ui/src/Divider/divider.css
+++ b/packages/froglet-ui/src/Divider/divider.css
@@ -1,0 +1,32 @@
+/*
+--------------------------------------------------------------------------------
+    Divider CSS File
+    Represents CSS Custom Property Style for Divider
+--------------------------------------------------------------------------------
+*/
+
+/* Base Divider Styles — horizontal (default) */
+.divider {
+  /* Box Model */
+  box-sizing: border-box;
+  width: var(--divider-width, 100%);
+  height: 0;
+  border: none;
+  border-top-width: var(--divider-border-width, 1px);
+  border-top-style: var(--divider-border-style, solid);
+  border-top-color: var(--divider-border-color);
+  margin: var(--divider-margin, 1rem 0);
+}
+
+/* Vertical Orientation */
+.divider--vertical {
+  /* Box Model */
+  width: 0;
+  height: var(--divider-height, 100%);
+  border-top: none;
+  border-left-width: var(--divider-border-width, 1px);
+  border-left-style: var(--divider-border-style, solid);
+  border-left-color: var(--divider-border-color);
+  margin: var(--divider-margin, 0 1rem);
+  align-self: stretch;
+}

--- a/packages/froglet-ui/src/Divider/index.ts
+++ b/packages/froglet-ui/src/Divider/index.ts
@@ -1,0 +1,2 @@
+export { Divider } from "./Divider";
+export type { DividerProps } from "./Divider";

--- a/packages/froglet-ui/src/index.ts
+++ b/packages/froglet-ui/src/index.ts
@@ -2,6 +2,8 @@ export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
 export { Checkbox } from "./Checkbox";
 export type { CheckboxProps } from "./Checkbox";
+export { Divider } from "./Divider";
+export type { DividerProps } from "./Divider";
 export { GridContainer } from "./Grid";
 export type { GridContainerProps } from "./Grid";
 export { GridItem } from "./Grid";


### PR DESCRIPTION
# Pull Request

## Issue Description

Adds `Divider` as Phase 4 component 1 of 12. `Divider` renders a semantic `<hr>` element styled entirely through CSS custom properties.

Key design decisions:
- Uses `<hr>` for implicit `role="separator"` and `aria-orientation="horizontal"` — no manual ARIA needed for the default case
- `orientation="vertical"` adds `.divider--vertical` and sets `aria-orientation="vertical"`
- `border-top-*` split into three separate declarations (not the `border-top` shorthand) to prevent the entire border from silently disappearing when `--divider-border-color` is unset — same shorthand-invalidation issue documented in CLAUDE.md for focus outlines
- `align-self: stretch` on `.divider--vertical` resolves the `height: 100%` flex cross-axis issue without requiring consumers to set an explicit parent height

## Testing Instructions

1. Run all checks from the monorepo root:
