### PR TITLE
feat: add label

### DIFF
--- a/apps/storybook/src/assets/css/label.storybook.css
+++ b/apps/storybook/src/assets/css/label.storybook.css
@@ -1,0 +1,5 @@
+.label--froglet {
+  --label-font-size: 0.875rem;
+  --label-font-weight: 500;
+  --label-text-color: var(--color-text);
+}

--- a/apps/storybook/src/stories/Label.stories.tsx
+++ b/apps/storybook/src/stories/Label.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Label } from "@froglet/ui";
+import { Checkbox, Input, Label, Radio, Select, Textarea } from "@froglet/ui";
+import "../assets/css/checkbox.storybook.css";
+import "../assets/css/input.storybook.css";
 import "../assets/css/label.storybook.css";
+import "../assets/css/radio.storybook.css";
+import "../assets/css/select.storybook.css";
+import "../assets/css/textarea.storybook.css";
 import readme from "../../../../packages/froglet-ui/src/Label/README.md?raw";
 
 // Strip the leading `# Label` heading — Storybook renders its own h1 from the story title.
@@ -95,6 +100,112 @@ export const WithInput: Story = {
       description: {
         story:
           "Label associated with an input via `htmlFor`. Clicking the label focuses the input. The `<input>` here is plain HTML to keep the story focused on Label.",
+      },
+    },
+  },
+};
+
+export const FormDemo: Story = {
+  render: () => (
+    <form
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1.25rem",
+        maxWidth: "24rem",
+      }}
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <div
+        style={{ display: "flex", flexDirection: "column", gap: "0.375rem" }}
+      >
+        <Label className="label--froglet" htmlFor="demo-email">
+          Email address
+        </Label>
+        <Input
+          className="input--froglet"
+          id="demo-email"
+          type="email"
+          placeholder="you@example.com"
+        />
+      </div>
+
+      <div
+        style={{ display: "flex", flexDirection: "column", gap: "0.375rem" }}
+      >
+        <Label className="label--froglet" htmlFor="demo-role">
+          Role
+        </Label>
+        <Select className="select--froglet" id="demo-role">
+          <option value="">Select a role...</option>
+          <option value="admin">Admin</option>
+          <option value="editor">Editor</option>
+          <option value="viewer">Viewer</option>
+        </Select>
+      </div>
+
+      <div
+        style={{ display: "flex", flexDirection: "column", gap: "0.375rem" }}
+      >
+        <Label className="label--froglet" htmlFor="demo-bio">
+          Bio
+        </Label>
+        <Textarea
+          className="textarea--froglet"
+          id="demo-bio"
+          placeholder="Tell us about yourself..."
+          rows={3}
+        />
+      </div>
+
+      <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+        <legend style={{ padding: 0 }}>
+          <Label
+            className="label--froglet"
+            style={{ display: "block", marginBottom: "0.375rem" }}
+          >
+            Notifications
+          </Label>
+        </legend>
+        <div
+          style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <Radio
+              className="radio--froglet"
+              name="notifications"
+              id="demo-notif-email"
+            />
+            <Label className="label--froglet" htmlFor="demo-notif-email">
+              Email
+            </Label>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <Radio
+              className="radio--froglet"
+              name="notifications"
+              id="demo-notif-sms"
+            />
+            <Label className="label--froglet" htmlFor="demo-notif-sms">
+              SMS
+            </Label>
+          </div>
+        </div>
+      </fieldset>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <Checkbox className="checkbox--froglet" id="demo-terms" />
+        <Label className="label--froglet" htmlFor="demo-terms">
+          I agree to the terms of service
+        </Label>
+      </div>
+    </form>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Label paired with all Froglet form controls: Input, Select, Textarea, Radio, and Checkbox. Each label is associated via `htmlFor`. Clicking any label focuses or activates its control.",
       },
     },
   },

--- a/apps/storybook/src/stories/Label.stories.tsx
+++ b/apps/storybook/src/stories/Label.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Label } from "@froglet/ui";
+import "../assets/css/label.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Label/README.md?raw";
+
+// Strip the leading `# Label` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+const meta = {
+  title: "Label",
+  component: Label,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "Email address",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The unstyled Label. No CSS custom properties are set — inherits surrounding text styles. Apply a modifier class to theme it.",
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  args: {
+    children: "Email address",
+    className: "label--froglet",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Themed with Froglet typography tokens.
+
+\`\`\`css
+.label--froglet {
+  --label-font-size: 0.875rem;
+  --label-font-weight: 500;
+  --label-text-color: #111827;
+}
+\`\`\``,
+      },
+    },
+  },
+};
+
+export const WithInput: Story = {
+  args: {
+    children: "Email address",
+    className: "label--froglet",
+    htmlFor: "email-demo",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.375rem",
+          width: "20rem",
+        }}
+      >
+        <Story />
+        <input
+          id="email-demo"
+          type="email"
+          placeholder="you@example.com"
+          style={{
+            border: "2px solid #d1d5db",
+            borderRadius: "6px",
+            padding: "10px 16px",
+            fontSize: "1rem",
+            fontFamily: "inherit",
+          }}
+        />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Label associated with an input via `htmlFor`. Clicking the label focuses the input. The `<input>` here is plain HTML to keep the story focused on Label.",
+      },
+    },
+  },
+};

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -189,6 +189,16 @@ All interactive components share a consistent shape language.
 }
 ```
 
+### Label
+
+```css
+.label--froglet {
+  --label-font-size: 0.875rem;
+  --label-font-weight: 500;
+  --label-text-color: #111827;
+}
+```
+
 ### Input
 
 ```css

--- a/packages/froglet-ui/src/Label/Label.test.tsx
+++ b/packages/froglet-ui/src/Label/Label.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Label } from "./Label";
+
+describe("Label", () => {
+  it("renders", () => {
+    render(<Label>Email</Label>);
+    expect(screen.getByText("Email")).toBeDefined();
+  });
+
+  it("applies className", () => {
+    render(<Label className="my-label">Email</Label>);
+    expect(screen.getByText("Email").classList.contains("my-label")).toBe(true);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLLabelElement>();
+    render(<Label ref={ref}>Email</Label>);
+    expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+  });
+});

--- a/packages/froglet-ui/src/Label/Label.tsx
+++ b/packages/froglet-ui/src/Label/Label.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { LabelHTMLAttributes, ReactNode } from "react";
+import classNames from "classnames";
+import "./label.css";
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  /** Label text or content. */
+  children?: ReactNode;
+  /** Additional CSS classes. Use to apply a token block. */
+  className?: string;
+  /** Ref forwarded to the underlying `<label>` element. */
+  ref?: React.Ref<HTMLLabelElement>;
+}
+
+/** A brandless label element styled entirely through CSS custom properties. */
+export const Label = ({ children, className, ref, ...props }: LabelProps) => {
+  return (
+    <label ref={ref} className={classNames("label", className)} {...props}>
+      {children}
+    </label>
+  );
+};

--- a/packages/froglet-ui/src/Label/README.md
+++ b/packages/froglet-ui/src/Label/README.md
@@ -1,0 +1,62 @@
+# Label
+
+A brandless label element. All visual styling is driven by CSS custom properties — no typography defaults are applied beyond `inherit`, so the component renders with surrounding text styles until tokens are provided.
+
+## Usage
+
+```tsx
+import { Label } from "@froglet/ui";
+
+<Label htmlFor="email">Email address</Label>;
+```
+
+Associates with a form control via `htmlFor`. Accepts all standard `<label>` attributes.
+
+### Wrapping a control
+
+```tsx
+<Label>
+  Email address
+  <input id="email" type="email" />
+</Label>
+```
+
+## Props
+
+| Prop        | Type                                    | Description                                                        |
+| ----------- | --------------------------------------- | ------------------------------------------------------------------ |
+| `children`  | `ReactNode`                             | Label text or content.                                             |
+| `className` | `string`                                | Additional CSS classes. Use to apply a token block (see Variants). |
+| `htmlFor`   | `string`                                | ID of the associated form control.                                 |
+| `ref`       | `React.Ref<HTMLLabelElement>`           | Forwarded to the underlying `<label>` element.                     |
+| `...props`  | `LabelHTMLAttributes<HTMLLabelElement>` | All standard HTML label attributes.                                |
+
+## CSS Custom Properties
+
+| Token                 | Default   | Description                                                      |
+| --------------------- | --------- | ---------------------------------------------------------------- |
+| `--label-font-family` | `inherit` | Font family                                                      |
+| `--label-font-size`   | `inherit` | Font size                                                        |
+| `--label-font-weight` | `inherit` | Font weight                                                      |
+| `--label-text-color`  | —         | Text color. No default; inherits surrounding `color` when unset. |
+| `--label-margin`      | `0`       | Outer spacing                                                    |
+
+Color tokens with no default (—) are intentionally bare: apply a modifier class to provide colors.
+
+## Variants
+
+Variants are not built into the component. Apply a CSS class that sets the appropriate tokens for your brand.
+
+```tsx
+<Label htmlFor="email" className="label--brand">
+  Email address
+</Label>
+```
+
+See the [Froglet Style Guide](../../../../docs/style-guide.md) for a reference implementation, or [Modifier Classes](../../../../docs/modifiers.md) for the general pattern.
+
+## Accessibility
+
+- `<label>` natively associates with a form control via `htmlFor` or by wrapping the control.
+- Click on a label focuses or activates the associated control — no JavaScript needed.
+- No focus ring is needed on the label itself; the associated control receives focus.

--- a/packages/froglet-ui/src/Label/index.ts
+++ b/packages/froglet-ui/src/Label/index.ts
@@ -1,0 +1,2 @@
+export { Label } from "./Label";
+export type { LabelProps } from "./Label";

--- a/packages/froglet-ui/src/Label/label.css
+++ b/packages/froglet-ui/src/Label/label.css
@@ -1,0 +1,19 @@
+/*
+--------------------------------------------------------------------------------
+    Label CSS File
+    Represents CSS Custom Property Style for Label
+--------------------------------------------------------------------------------
+*/
+
+/* Base Label Styles */
+.label {
+  /* Box Model */
+  box-sizing: border-box;
+  margin: var(--label-margin, 0);
+
+  /* Typography */
+  font-family: var(--label-font-family, inherit);
+  font-size: var(--label-font-size, inherit);
+  font-weight: var(--label-font-weight, inherit);
+  color: var(--label-text-color);
+}

--- a/packages/froglet-ui/src/index.ts
+++ b/packages/froglet-ui/src/index.ts
@@ -10,6 +10,8 @@ export { GridItem } from "./Grid";
 export type { GridItemProps } from "./Grid";
 export { Input } from "./Input";
 export type { InputProps } from "./Input";
+export { Label } from "./Label";
+export type { LabelProps } from "./Label";
 export { Link } from "./Link";
 export type { LinkProps } from "./Link";
 export { Radio } from "./Radio";


### PR DESCRIPTION
# Pull Request

## Issue Description

Adds `Label` as Phase 4 component 2 of 12. `Label` wraps the native `<label>` element, exposing typography as CSS custom properties.

Key design decisions:
- `LabelHTMLAttributes<HTMLLabelElement>` as the base interface — `htmlFor` passes through natively with no extra code
- Typography-only token set: `font-family`, `font-size`, `font-weight`, `text-color`, `margin`. No border, hover, or focus tokens — `<label>` is not an interactive control
- Bare `var()` on `--label-text-color`: `color`'s initial value is inherited, so an unstyled label renders with surrounding text color
- `FormDemo` story imports all five Froglet form controls (`Input`, `Select`, `Textarea`, `Radio`, `Checkbox`) and shows them paired with labeled associations via `htmlFor`. Radio group uses `<fieldset>/<legend>` for correct ARIA grouping

## Testing Instructions

1. Run all checks from the monorepo root:

```
npm run format && npm run lint && npm run check-types && npm run test
```

Expected: 40 tests pass, lint clean, types clean.

2. Start Storybook:

```
npm run dev
```

- **Default** story: label text inheriting surrounding styles, no className
- **Froglet** story: `0.875rem / 500 / #111827` typography
- **WithInput** story: label above a plain `<input>`; clicking the label focuses the input
- **FormDemo** story: full form with labeled Input, Select, Textarea, Radio group (fieldset), and Checkbox — clicking each label should focus or activate the associated control
- Docs tab: README rendered as component description, CSS code block in Froglet story