### PR TITLE
feat(badge): add Badge component

### DIFF
--- a/apps/storybook/src/assets/css/badge.storybook.css
+++ b/apps/storybook/src/assets/css/badge.storybook.css
@@ -1,0 +1,8 @@
+.badge--froglet {
+  --badge-background-color: #f3f4f6;
+  --badge-text-color: var(--color-text);
+  --badge-border-radius: 9999px;
+  --badge-font-size: 0.75rem;
+  --badge-font-weight: 600;
+  --badge-padding: 0.125rem 0.5rem;
+}

--- a/apps/storybook/src/stories/Badge.stories.tsx
+++ b/apps/storybook/src/stories/Badge.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Badge } from "@froglet/ui";
+import "../assets/css/badge.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Badge/README.md?raw";
+
+// Strip the leading `# Badge` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+const meta = {
+  title: "Badge",
+  component: Badge,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "New",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The base Badge with no modifier class applied. Unlike native form elements, `<span>` has no browser UA styles — so the base `.badge` class provides neutral gray fallbacks (`#e5e7eb` background, `#374151` text, pill shape) to ensure it renders as a recognizable badge out of the box. Override any token with a modifier class.",
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  args: {
+    children: "New",
+    className: "badge--froglet",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Themed with Froglet visual tokens — gray pill shape.
+
+\`\`\`css
+.badge--froglet {
+  --badge-background-color: #f3f4f6;
+  --badge-text-color: var(--color-text);
+  --badge-border-radius: 9999px;
+  --badge-font-size: 0.75rem;
+  --badge-font-weight: 600;
+  --badge-padding: 0.125rem 0.5rem;
+}
+\`\`\``,
+      },
+    },
+  },
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      <Badge className="badge--froglet">Default</Badge>
+      <Badge
+        className="badge--froglet"
+        style={
+          {
+            "--badge-background-color": "#dbeafe",
+            "--badge-text-color": "#1e40af",
+          } as React.CSSProperties
+        }
+      >
+        Blue
+      </Badge>
+      <Badge
+        className="badge--froglet"
+        style={
+          {
+            "--badge-background-color": "#dcfce7",
+            "--badge-text-color": "#15803d",
+          } as React.CSSProperties
+        }
+      >
+        Green
+      </Badge>
+      <Badge
+        className="badge--froglet"
+        style={
+          {
+            "--badge-background-color": "#fee2e2",
+            "--badge-text-color": "#b91c1c",
+          } as React.CSSProperties
+        }
+      >
+        Red
+      </Badge>
+      <Badge
+        className="badge--froglet"
+        style={
+          {
+            "--badge-background-color": "#fef9c3",
+            "--badge-text-color": "#854d0e",
+          } as React.CSSProperties
+        }
+      >
+        Yellow
+      </Badge>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All badges share the `badge--froglet` base class for shape and typography. Color variants are applied by overriding `--badge-background-color` and `--badge-text-color` inline — no extra CSS classes needed.",
+      },
+    },
+  },
+};

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -151,6 +151,19 @@ All interactive components share a consistent shape language.
 }
 ```
 
+### Badge
+
+```css
+.badge--froglet {
+  --badge-background-color: #f3f4f6;
+  --badge-text-color: #374151;
+  --badge-border-radius: 9999px;
+  --badge-font-size: 0.75rem;
+  --badge-font-weight: 600;
+  --badge-padding: 0.125rem 0.5rem;
+}
+```
+
 ### Checkbox
 
 ```css

--- a/packages/froglet-ui/src/Badge/Badge.test.tsx
+++ b/packages/froglet-ui/src/Badge/Badge.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./Badge";
+
+describe("Badge", () => {
+  it("renders", () => {
+    render(<Badge>New</Badge>);
+    expect(screen.getByText("New")).toBeDefined();
+  });
+
+  it("applies className", () => {
+    render(<Badge className="my-badge">New</Badge>);
+    expect(screen.getByText("New").classList.contains("my-badge")).toBe(true);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLSpanElement>();
+    render(<Badge ref={ref}>New</Badge>);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+});

--- a/packages/froglet-ui/src/Badge/Badge.tsx
+++ b/packages/froglet-ui/src/Badge/Badge.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { HTMLAttributes, ReactNode } from "react";
+import classNames from "classnames";
+import "./badge.css";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  /** Badge text or content. */
+  children?: ReactNode;
+  /** Additional CSS classes. Use to apply a token block. */
+  className?: string;
+  /** Ref forwarded to the underlying `<span>` element. */
+  ref?: React.Ref<HTMLSpanElement>;
+}
+
+/** A brandless inline badge styled entirely through CSS custom properties. */
+export const Badge = ({ children, className, ref, ...props }: BadgeProps) => {
+  return (
+    <span ref={ref} className={classNames("badge", className)} {...props}>
+      {children}
+    </span>
+  );
+};

--- a/packages/froglet-ui/src/Badge/README.md
+++ b/packages/froglet-ui/src/Badge/README.md
@@ -1,0 +1,60 @@
+# Badge
+
+A brandless inline badge element. All visual styling is driven by CSS custom properties. Unlike native form elements, `<span>` carries no browser UA styles — so the base `.badge` class ships with neutral gray fallbacks to ensure the component renders as a recognizable badge without any modifier class applied.
+
+## Usage
+
+```tsx
+import { Badge } from "@froglet/ui";
+
+<Badge>New</Badge>;
+```
+
+Apply a modifier class to theme it:
+
+```tsx
+<Badge className="badge--brand">New</Badge>
+```
+
+## Props
+
+| Prop        | Type                              | Description                                                        |
+| ----------- | --------------------------------- | ------------------------------------------------------------------ |
+| `children`  | `ReactNode`                       | Badge text or content.                                             |
+| `className` | `string`                          | Additional CSS classes. Use to apply a token block (see Variants). |
+| `ref`       | `React.Ref<HTMLSpanElement>`      | Forwarded to the underlying `<span>` element.                      |
+| `...props`  | `HTMLAttributes<HTMLSpanElement>` | All standard HTML span attributes.                                 |
+
+## CSS Custom Properties
+
+| Token                      | Default           | Description                                                              |
+| -------------------------- | ----------------- | ------------------------------------------------------------------------ |
+| `--badge-background-color` | `#e5e7eb`         | Background fill.                                                         |
+| `--badge-text-color`       | `#374151`         | Text color.                                                              |
+| `--badge-border-radius`    | `9999px`          | Corner rounding (pill shape).                                            |
+| `--badge-padding`          | `0.125rem 0.5rem` | Inner spacing.                                                           |
+| `--badge-font-family`      | `inherit`         | Font family.                                                             |
+| `--badge-font-size`        | `inherit`         | Font size.                                                               |
+| `--badge-font-weight`      | `inherit`         | Font weight.                                                             |
+| `--badge-line-height`      | `inherit`         | Line height.                                                             |
+| `--badge-border-width`     | `0`               | Border width. Set to `1px` to enable an outline badge.                   |
+| `--badge-border-style`     | `solid`           | Border style.                                                            |
+| `--badge-border-color`     | —                 | Border color. Bare var; only visible when `--badge-border-width` is set. |
+
+Only `--badge-border-color` is intentionally bare — it is only visible when `--badge-border-width` is set, so no fallback is needed.
+
+## Variants
+
+Variants are not built into the component. Apply a CSS class that sets the appropriate tokens for your brand.
+
+```tsx
+<Badge className="badge--brand">New</Badge>
+```
+
+See the [Froglet Style Guide](../../../../docs/style-guide.md) for a reference implementation, or [Modifier Classes](../../../../docs/modifiers.md) for the general pattern.
+
+## Accessibility
+
+- `<span>` has no implicit ARIA role. For a live-region notification badge (e.g. an unread count), add `role="status"` and `aria-live="polite"`.
+- For purely decorative indicators, no additional ARIA is needed.
+- Ensure text contrast meets WCAG AA (4.5:1 for normal text, 3:1 for large text) when choosing background and text token values.

--- a/packages/froglet-ui/src/Badge/badge.css
+++ b/packages/froglet-ui/src/Badge/badge.css
@@ -1,0 +1,32 @@
+/*
+--------------------------------------------------------------------------------
+    Badge CSS File
+    Represents CSS Custom Property Style for Badge
+--------------------------------------------------------------------------------
+*/
+
+/* Base Badge Styles */
+.badge {
+  /* Display */
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+
+  /* Box Model */
+  box-sizing: border-box;
+  padding: var(--badge-padding, 0.125rem 0.5rem);
+  border-width: var(--badge-border-width, 0);
+  border-style: var(--badge-border-style, solid);
+  border-color: var(--badge-border-color);
+  border-radius: var(--badge-border-radius, 9999px);
+
+  /* Typography */
+  font-family: var(--badge-font-family, inherit);
+  font-size: var(--badge-font-size, inherit);
+  font-weight: var(--badge-font-weight, inherit);
+  line-height: var(--badge-line-height, inherit);
+  color: var(--badge-text-color, #374151);
+
+  /* Visual */
+  background-color: var(--badge-background-color, #e5e7eb);
+}

--- a/packages/froglet-ui/src/Badge/index.ts
+++ b/packages/froglet-ui/src/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from "./Badge";
+export type { BadgeProps } from "./Badge";

--- a/packages/froglet-ui/src/index.ts
+++ b/packages/froglet-ui/src/index.ts
@@ -1,3 +1,5 @@
+export { Badge } from "./Badge";
+export type { BadgeProps } from "./Badge";
 export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
 export { Checkbox } from "./Checkbox";


### PR DESCRIPTION
## Summary

- Adds `Badge` — a brandless inline badge component backed by CSS custom properties
- Ships neutral gray fallbacks in the base `.badge` class (background `#e5e7eb`, text `#374151`, pill shape, standard padding) so the component renders visibly without a modifier class — unlike previous components, `<span>` carries no browser UA styles
- Exports `Badge` and `BadgeProps` from `@froglet/ui`; adds `badge--froglet` reference implementation to the style guide and Storybook (Default, Froglet, Colors stories)

## Test plan

- [ ] 43 tests pass (`npm run test`)
- [ ] Lint clean (`npm run lint`)
- [ ] Types clean (`npm run check-types`)
- [ ] Storybook: Default story renders a visible gray pill with no modifier class
- [ ] Storybook: Colors story shows token overrides applied inline without extra CSS classes
