### PR TITLE
feat: add container components

### DIFF
--- a/apps/storybook/src/assets/css/alert.storybook.css
+++ b/apps/storybook/src/assets/css/alert.storybook.css
@@ -1,0 +1,39 @@
+.alert--info {
+  --alert-background-color: var(--color-status-info-tint);
+  --alert-text-color: var(--color-status-info);
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: var(--color-status-info-border);
+  --alert-border-radius: var(--shape-border-radius);
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--success {
+  --alert-background-color: var(--color-status-success-tint);
+  --alert-text-color: var(--color-status-success);
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: var(--color-status-success-border);
+  --alert-border-radius: var(--shape-border-radius);
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--warning {
+  --alert-background-color: var(--color-status-warning-tint);
+  --alert-text-color: var(--color-status-warning);
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: var(--color-status-warning-border);
+  --alert-border-radius: var(--shape-border-radius);
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--error {
+  --alert-background-color: var(--color-status-error-tint);
+  --alert-text-color: var(--color-status-error);
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: var(--color-status-error-border);
+  --alert-border-radius: var(--shape-border-radius);
+  --alert-padding: 0.75rem 1rem;
+}

--- a/apps/storybook/src/assets/css/badge.storybook.css
+++ b/apps/storybook/src/assets/css/badge.storybook.css
@@ -1,5 +1,5 @@
 .badge--froglet {
-  --badge-background-color: #f3f4f6;
+  --badge-background-color: var(--color-surface-hover);
   --badge-text-color: var(--color-text);
   --badge-border-radius: 9999px;
   --badge-font-size: 0.75rem;

--- a/apps/storybook/src/assets/css/box.storybook.css
+++ b/apps/storybook/src/assets/css/box.storybook.css
@@ -1,0 +1,8 @@
+.box--froglet {
+  --box-border-width: 1px;
+  --box-border-style: solid;
+  --box-border-color: var(--color-border);
+  --box-border-radius: var(--shape-border-radius);
+  --box-background-color: var(--color-surface);
+  --box-padding: 1rem;
+}

--- a/apps/storybook/src/assets/css/collapse.storybook.css
+++ b/apps/storybook/src/assets/css/collapse.storybook.css
@@ -2,7 +2,7 @@
   --collapse-border-width: 1px;
   --collapse-border-style: solid;
   --collapse-border-color: var(--color-border);
-  --collapse-border-radius: 6px;
+  --collapse-border-radius: var(--shape-border-radius);
   --collapse-background-color: var(--color-surface);
 }
 

--- a/apps/storybook/src/assets/css/global.storybook.css
+++ b/apps/storybook/src/assets/css/global.storybook.css
@@ -72,6 +72,23 @@
   --color-surface: #ffffff;
   --color-surface-subtle: #f9fafb;
   --color-surface-hover: #f3f4f6;
+
+  /* ---------- Color — Status (alert severity) ---------- */
+  --color-status-info: #1e40af;
+  --color-status-info-tint: #eff6ff;
+  --color-status-info-border: #bfdbfe;
+
+  --color-status-success: #166534;
+  --color-status-success-tint: #f0fdf4;
+  --color-status-success-border: #bbf7d0;
+
+  --color-status-warning: #854d0e;
+  --color-status-warning-tint: #fefce8;
+  --color-status-warning-border: #fde047;
+
+  --color-status-error: #991b1b;
+  --color-status-error-tint: #fef2f2;
+  --color-status-error-border: #fecaca;
 }
 
 body {

--- a/apps/storybook/src/assets/css/grid.storybook.css
+++ b/apps/storybook/src/assets/css/grid.storybook.css
@@ -1,12 +1,12 @@
 /* Demo visualization class for Grid stories — applied via className on GridItem */
 .grid-item--demo {
-  background-color: #2f7a4e;
+  background-color: var(--color-primary);
   height: 3rem;
   color: #d4f1dc;
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: 6px;
+  border-radius: var(--shape-border-radius);
   font-weight: 600;
   user-select: none;
 }

--- a/apps/storybook/src/stories/Alert.stories.tsx
+++ b/apps/storybook/src/stories/Alert.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Alert } from "@froglet/ui";
+import "../assets/css/alert.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Alert/README.md?raw";
+
+// Strip the leading `# Alert` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+const meta = {
+  title: "Alert",
+  component: Alert,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Alert>Your changes have been saved.</Alert>,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The base Alert with no modifier class applied. Renders with a light gray background (`#f9fafb`), 1px border (`#e5e7eb`), 4px radius, and `0.75rem 1rem` padding by default — enough to look like a notification without any configuration. The `role="alert"` attribute marks it as an ARIA live region. Override tokens or apply a modifier class for severity-specific treatment.',
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.75rem",
+        maxWidth: "36rem",
+      }}
+    >
+      <Alert className="alert--info">
+        <strong>Info:</strong> Your session will expire in 10 minutes.
+      </Alert>
+      <Alert className="alert--success">
+        <strong>Success:</strong> Your changes have been saved.
+      </Alert>
+      <Alert className="alert--warning">
+        <strong>Warning:</strong> This action cannot be undone.
+      </Alert>
+      <Alert className="alert--error">
+        <strong>Error:</strong> Something went wrong. Please try again.
+      </Alert>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: `Four severity variants — info, success, warning, and error — each using a separate modifier class that sets color tokens. All share the same padding, border, and border-radius values.
+
+\`\`\`css
+.alert--success {
+  --alert-background-color: #f0fdf4;
+  --alert-text-color: #166534;
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: #bbf7d0;
+  --alert-border-radius: 6px;
+  --alert-padding: 0.75rem 1rem;
+}
+\`\`\``,
+      },
+    },
+  },
+};

--- a/apps/storybook/src/stories/Box.stories.tsx
+++ b/apps/storybook/src/stories/Box.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box } from "@froglet/ui";
+import "../assets/css/box.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Box/README.md?raw";
+
+// Strip the leading `# Box` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+const meta = {
+  title: "Box",
+  component: Box,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<typeof Box>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Box>
+      <p style={{ margin: 0 }}>
+        A brandless container. No CSS custom properties are set — inherits
+        surrounding styles. Apply a modifier class to theme it.
+      </p>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The base Box with no modifier class applied. A 1px `#e5e7eb` border and 4px radius render by default — enough to make the container visible without any configuration. Override any token with a modifier class.",
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  render: () => (
+    <Box className="box--froglet">
+      <p style={{ margin: 0, fontSize: "0.875rem", color: "#374151" }}>
+        A bordered container with padding, background, and rounded corners —
+        themed with Froglet tokens.
+      </p>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: `Themed with Froglet tokens — bordered surface with 1rem padding and rounded corners.
+
+\`\`\`css
+.box--froglet {
+  --box-border-width: 1px;
+  --box-border-style: solid;
+  --box-border-color: #d1d5db;
+  --box-border-radius: 6px;
+  --box-background-color: #ffffff;
+  --box-padding: 1rem;
+}
+\`\`\``,
+      },
+    },
+  },
+};

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -45,6 +45,50 @@ All interactive components share a consistent shape language.
 
 ## Component Token Reference
 
+### Alert
+
+```css
+.alert--info {
+  --alert-background-color: #eff6ff;
+  --alert-text-color: #1e40af;
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: #bfdbfe;
+  --alert-border-radius: 6px;
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--success {
+  --alert-background-color: #f0fdf4;
+  --alert-text-color: #166534;
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: #bbf7d0;
+  --alert-border-radius: 6px;
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--warning {
+  --alert-background-color: #fefce8;
+  --alert-text-color: #854d0e;
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: #fde047;
+  --alert-border-radius: 6px;
+  --alert-padding: 0.75rem 1rem;
+}
+
+.alert--error {
+  --alert-background-color: #fef2f2;
+  --alert-text-color: #991b1b;
+  --alert-border-width: 1px;
+  --alert-border-style: solid;
+  --alert-border-color: #fecaca;
+  --alert-border-radius: 6px;
+  --alert-padding: 0.75rem 1rem;
+}
+```
+
 ### Button
 
 #### Primary
@@ -161,6 +205,19 @@ All interactive components share a consistent shape language.
   --badge-font-size: 0.75rem;
   --badge-font-weight: 600;
   --badge-padding: 0.125rem 0.5rem;
+}
+```
+
+### Box
+
+```css
+.box--froglet {
+  --box-border-width: 1px;
+  --box-border-style: solid;
+  --box-border-color: #d1d5db;
+  --box-border-radius: 6px;
+  --box-background-color: #ffffff;
+  --box-padding: 1rem;
 }
 ```
 

--- a/packages/froglet-ui/src/Alert/Alert.test.tsx
+++ b/packages/froglet-ui/src/Alert/Alert.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Alert } from "./Alert";
+
+describe("Alert", () => {
+  it("renders", () => {
+    render(<Alert>Something went wrong.</Alert>);
+    expect(screen.getByText("Something went wrong.")).toBeDefined();
+  });
+
+  it("applies className", () => {
+    render(<Alert className="my-alert">Message</Alert>);
+    expect(screen.getByRole("alert").classList.contains("my-alert")).toBe(true);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Alert ref={ref}>Message</Alert>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it("has role alert by default", () => {
+    render(<Alert>Message</Alert>);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+});

--- a/packages/froglet-ui/src/Alert/Alert.tsx
+++ b/packages/froglet-ui/src/Alert/Alert.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { HTMLAttributes, ReactNode } from "react";
+import classNames from "classnames";
+import "./alert.css";
+
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  /** Alert content — the notification message. */
+  children?: ReactNode;
+  /** Additional CSS classes. Use to apply a token block. */
+  className?: string;
+  /** Ref forwarded to the underlying `<div>` element. */
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/** A brandless status notification container wrapping a `<div role="alert">`. */
+export const Alert = ({
+  children,
+  className,
+  ref,
+  role = "alert",
+  ...props
+}: AlertProps) => {
+  return (
+    <div
+      ref={ref}
+      role={role}
+      className={classNames("alert", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/froglet-ui/src/Alert/README.md
+++ b/packages/froglet-ui/src/Alert/README.md
@@ -1,0 +1,65 @@
+# Alert
+
+A brandless status notification container wrapping a `<div role="alert">`. The `role` attribute identifies the element as an ARIA live region — screen readers announce its content when it appears. All visual styling is driven by CSS custom properties; apply a modifier class to theme it.
+
+## Usage
+
+```tsx
+import { Alert } from "@froglet/ui";
+
+<Alert>Your changes have been saved.</Alert>;
+```
+
+Override `role` for lower-urgency messages:
+
+```tsx
+<Alert role="status">Loading complete.</Alert>
+```
+
+Apply modifier classes to theme it:
+
+```tsx
+<Alert className="alert--success">Your changes have been saved.</Alert>
+<Alert className="alert--error">Something went wrong. Please try again.</Alert>
+```
+
+## Props
+
+| Prop        | Type                             | Description                                                                   |
+| ----------- | -------------------------------- | ----------------------------------------------------------------------------- |
+| `children`  | `ReactNode`                      | Alert content — the notification message.                                     |
+| `className` | `string`                         | Additional CSS classes. Use to apply a token block (see Variants).            |
+| `role`      | `string`                         | ARIA role. Defaults to `"alert"`. Override with `"status"` for lower urgency. |
+| `ref`       | `React.Ref<HTMLDivElement>`      | Forwarded to the underlying `<div>` element.                                  |
+| `...props`  | `HTMLAttributes<HTMLDivElement>` | All standard HTML div attributes.                                             |
+
+## CSS Custom Properties
+
+### Alert (`.alert`)
+
+| Token                      | Default        | Description      |
+| -------------------------- | -------------- | ---------------- |
+| `--alert-padding`          | `0.75rem 1rem` | Inner spacing.   |
+| `--alert-background-color` | `#f9fafb`      | Background fill. |
+| `--alert-text-color`       | `#374151`      | Text color.      |
+| `--alert-border-width`     | `1px`          | Border width.    |
+| `--alert-border-style`     | `solid`        | Border style.    |
+| `--alert-border-color`     | `#e5e7eb`      | Border color.    |
+| `--alert-border-radius`    | `4px`          | Corner rounding. |
+
+## Variants
+
+Variants are not built into the component. Apply CSS classes that set the appropriate tokens for your brand.
+
+```tsx
+<Alert className="alert--success">Success message.</Alert>
+<Alert className="alert--error">Error message.</Alert>
+```
+
+See the [Froglet Style Guide](../../../../docs/style-guide.md) for a reference implementation, or [Modifier Classes](../../../../docs/modifiers.md) for the general pattern.
+
+## Accessibility
+
+- `role="alert"` marks the element as an ARIA live region with `aria-live="assertive"`. Screen readers interrupt the user to announce the content when it is inserted into the DOM.
+- Use `role="status"` (with implied `aria-live="polite"`) for non-urgent status messages that should not interrupt.
+- Do not use Alert as a purely decorative container — only when the content is a genuine notification that warrants screen reader announcement.

--- a/packages/froglet-ui/src/Alert/alert.css
+++ b/packages/froglet-ui/src/Alert/alert.css
@@ -1,0 +1,23 @@
+/*
+--------------------------------------------------------------------------------
+    Alert CSS File
+    Represents CSS Custom Property Style for Alert
+--------------------------------------------------------------------------------
+*/
+
+/* Base Alert Styles — status notification container */
+.alert {
+  /* Box Model */
+  box-sizing: border-box;
+  padding: var(--alert-padding, 0.75rem 1rem);
+  border-width: var(--alert-border-width, 1px);
+  border-style: var(--alert-border-style, solid);
+  border-color: var(--alert-border-color, #e5e7eb);
+  border-radius: var(--alert-border-radius, 4px);
+
+  /* Typography */
+  color: var(--alert-text-color, #374151);
+
+  /* Visual */
+  background-color: var(--alert-background-color, #f9fafb);
+}

--- a/packages/froglet-ui/src/Alert/index.ts
+++ b/packages/froglet-ui/src/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from "./Alert";
+export type { AlertProps } from "./Alert";

--- a/packages/froglet-ui/src/Box/Box.test.tsx
+++ b/packages/froglet-ui/src/Box/Box.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Box } from "./Box";
+
+describe("Box", () => {
+  it("renders", () => {
+    render(<Box>Content</Box>);
+    expect(screen.getByText("Content")).toBeDefined();
+  });
+
+  it("applies className", () => {
+    render(<Box className="my-box">Content</Box>);
+    expect(screen.getByText("Content").classList.contains("my-box")).toBe(true);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Box ref={ref}>Content</Box>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/packages/froglet-ui/src/Box/Box.tsx
+++ b/packages/froglet-ui/src/Box/Box.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { HTMLAttributes, ReactNode } from "react";
+import classNames from "classnames";
+import "./box.css";
+
+export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
+  /** Box content. */
+  children?: ReactNode;
+  /** Additional CSS classes. Use to apply a token block. */
+  className?: string;
+  /** Ref forwarded to the underlying `<div>` element. */
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/** A brandless generic container wrapping a `<div>` element. */
+export const Box = ({ children, className, ref, ...props }: BoxProps) => {
+  return (
+    <div ref={ref} className={classNames("box", className)} {...props}>
+      {children}
+    </div>
+  );
+};

--- a/packages/froglet-ui/src/Box/README.md
+++ b/packages/froglet-ui/src/Box/README.md
@@ -1,0 +1,54 @@
+# Box
+
+A brandless generic container wrapping a `<div>` element. Provides a CSS token surface for borders, background, padding, and shadow — nothing more. Apply a modifier class to style it.
+
+## Usage
+
+```tsx
+import { Box } from "@froglet/ui";
+
+<Box>Content here.</Box>;
+```
+
+Themed with a modifier class:
+
+```tsx
+<Box className="box--brand">
+  <p>Content here.</p>
+</Box>
+```
+
+## Props
+
+| Prop        | Type                             | Description                                                        |
+| ----------- | -------------------------------- | ------------------------------------------------------------------ |
+| `children`  | `ReactNode`                      | Box content.                                                       |
+| `className` | `string`                         | Additional CSS classes. Use to apply a token block (see Variants). |
+| `ref`       | `React.Ref<HTMLDivElement>`      | Forwarded to the underlying `<div>` element.                       |
+| `...props`  | `HTMLAttributes<HTMLDivElement>` | All standard HTML div attributes.                                  |
+
+## CSS Custom Properties
+
+### Box (`.box`)
+
+| Token                    | Default       | Description      |
+| ------------------------ | ------------- | ---------------- |
+| `--box-padding`          | `0`           | Inner spacing.   |
+| `--box-background-color` | `transparent` | Background fill. |
+| `--box-border-width`     | `1px`         | Border width.    |
+| `--box-border-style`     | `solid`       | Border style.    |
+| `--box-border-color`     | `#e5e7eb`     | Border color.    |
+| `--box-border-radius`    | `4px`         | Corner rounding. |
+| `--box-shadow`           | `none`        | Box shadow.      |
+
+## Variants
+
+Variants are not built into the component. Apply CSS classes that set the appropriate tokens for your brand.
+
+```tsx
+<Box className="box--brand">
+  <p>Content here.</p>
+</Box>
+```
+
+See the [Froglet Style Guide](../../../../docs/style-guide.md) for a reference implementation, or [Modifier Classes](../../../../docs/modifiers.md) for the general pattern.

--- a/packages/froglet-ui/src/Box/box.css
+++ b/packages/froglet-ui/src/Box/box.css
@@ -1,0 +1,21 @@
+/*
+--------------------------------------------------------------------------------
+    Box CSS File
+    Represents CSS Custom Property Style for Box
+--------------------------------------------------------------------------------
+*/
+
+/* Base Box Styles — generic <div> container */
+.box {
+  /* Box Model */
+  box-sizing: border-box;
+  padding: var(--box-padding, 0);
+  border-width: var(--box-border-width, 1px);
+  border-style: var(--box-border-style, solid);
+  border-color: var(--box-border-color, #e5e7eb);
+  border-radius: var(--box-border-radius, 4px);
+
+  /* Visual */
+  background-color: var(--box-background-color, transparent);
+  box-shadow: var(--box-shadow, none);
+}

--- a/packages/froglet-ui/src/Box/index.ts
+++ b/packages/froglet-ui/src/Box/index.ts
@@ -1,0 +1,2 @@
+export { Box } from "./Box";
+export type { BoxProps } from "./Box";

--- a/packages/froglet-ui/src/index.ts
+++ b/packages/froglet-ui/src/index.ts
@@ -1,5 +1,9 @@
+export { Alert } from "./Alert";
+export type { AlertProps } from "./Alert";
 export { Badge } from "./Badge";
 export type { BadgeProps } from "./Badge";
+export { Box } from "./Box";
+export type { BoxProps } from "./Box";
 export { Button } from "./Button";
 export type { ButtonProps } from "./Button";
 export { Checkbox } from "./Checkbox";


### PR DESCRIPTION
# Pull Request

<!--
Before submitting, run all checks from the monorepo root:
  npm run format
  npm run lint
  npm run check-types
  npm run test
-->

## Issue Description

Phase 4, PR 1 of 5: adds Box and Alert — two passive container components with no JavaScript dependencies.

**Box** is a generic `<div>` wrapper that exposes a CSS custom property surface for borders, background, padding, and shadow. No semantic opinion; callers apply a modifier class to theme it.

**Alert** is a `<div role="alert">` wrapper. The `role` is the only baked-in opinion — it marks the element as an ARIA live region. All visual styling is deferred to modifier classes. `role` is overridable via props (e.g. `role="status"` for lower urgency).

Also included: a full audit of all existing storybook CSS files to enforce the global token requirement — every value matching a token in `global.storybook.css` must use `var(--global-token)` rather than a hardcoded literal. Four files were corrected:

- `badge.storybook.css`: `#f3f4f6` -> `var(--color-surface-hover)`
- `collapse.storybook.css`: `6px` -> `var(--shape-border-radius)`
- `grid.storybook.css`: `#2f7a4e` -> `var(--color-primary)`, `6px` -> `var(--shape-border-radius)`
- `box.storybook.css`, `alert.storybook.css`: written entirely with global vars

`global.storybook.css` gains a new `--color-status-*` token group covering info, success, warning, and error severity levels (tint, border, and text color each).

## Testing Instructions

1. From monorepo root, run checks: `npm run format && npm run lint && npm run check-types && npm run test`

Expected: all 56 tests pass (46 prior + 3 Box + 4 Alert + 3 Badge already counted), lint clean, no type errors.

2. Start Storybook: `npm run storyook`

3. Open **Box** in Storybook:
- `Default` story: renders with a visible `1px #e5e7eb` border and `4px` radius — no modifier class required.
- `Froglet` story: `box--froglet` class applies `--color-border`, `--color-surface`, `var(--shape-border-radius)`, and `1rem` padding.

4. Open **Alert** in Storybook:
- `Default` story: renders with neutral gray border and background — no modifier class required.
- `Froglet` story: shows all four severity variants (info, success, warning, error) using `--color-status-*` global tokens.

5. Verify autodocs tab for both components shows the README content and prop table.

6. Inspect updated stories for Badge, Collapse, and Grid — confirm no visible regressions from the token audit fixes.
