### PR TITLE
feat(table): add Table component, controls pass

### DIFF
--- a/apps/storybook/src/assets/css/table.storybook.css
+++ b/apps/storybook/src/assets/css/table.storybook.css
@@ -1,0 +1,12 @@
+.table--froglet {
+  --table-th-background-color: var(--color-surface-subtle);
+  --table-th-text-color: var(--color-text);
+  --table-th-border-bottom-width: var(--shape-border-width);
+  --table-th-border-bottom-color: var(--color-border);
+  --table-tr-background-color-even: var(--color-surface-subtle);
+  --table-tr-background-color-odd: var(--color-surface);
+  --table-td-text-color: var(--color-text);
+  --table-td-border-bottom-width: 1px;
+  --table-td-border-bottom-color: var(--color-border);
+  --table-caption-text-color: var(--color-text-subtle);
+}

--- a/apps/storybook/src/stories/Button.stories.tsx
+++ b/apps/storybook/src/stories/Button.stories.tsx
@@ -17,6 +17,11 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
 } satisfies Meta<typeof Button>;
 
 export default meta;

--- a/apps/storybook/src/stories/Divider.stories.tsx
+++ b/apps/storybook/src/stories/Divider.stories.tsx
@@ -17,6 +17,12 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    orientation: {
+      control: { type: "select" },
+      options: ["horizontal", "vertical"],
+    },
+  },
 } satisfies Meta<typeof Divider>;
 
 export default meta;

--- a/apps/storybook/src/stories/Grid.stories.tsx
+++ b/apps/storybook/src/stories/Grid.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
   argTypes: {
     columns: { control: { type: "number" } },
     gap: { control: { type: "text" } },
+    autoRows: { control: { type: "text" } },
     autoFlow: {
       control: { type: "select" },
       options: ["row", "column", "row dense", "column dense"],
@@ -77,6 +78,10 @@ export const Default: Story = {
       </GridItem>
     </GridContainer>
   ),
+  args: {
+    columns: 12,
+    gap: "1rem",
+  },
   parameters: {
     docs: {
       description: {
@@ -104,12 +109,16 @@ export const Controls: Story = {
   args: {
     columns: 3,
     gap: "1rem",
+    autoRows: "auto",
+    autoFlow: "row",
+    justifyContent: "start",
+    alignContent: "start",
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Use the Controls panel to adjust `columns`, `gap`, `autoFlow`, `justifyContent`, and `alignContent`. All values set CSS custom properties on the container.",
+          "Use the Controls panel to adjust `columns`, `gap`, `autoRows`, `autoFlow`, `justifyContent`, and `alignContent`. All values set CSS custom properties on the container.",
       },
     },
   },

--- a/apps/storybook/src/stories/Progress.stories.tsx
+++ b/apps/storybook/src/stories/Progress.stories.tsx
@@ -17,13 +17,22 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    value: {
+      control: { type: "range", min: 0, max: 1, step: 0.05 },
+    },
+  },
 } satisfies Meta<typeof Progress>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => <Progress value={0.6} max={1} />,
+  render: (args) => <Progress {...args} />,
+  args: {
+    value: 0.6,
+    max: 1,
+  },
   parameters: {
     docs: {
       description: {
@@ -35,7 +44,7 @@ export const Default: Story = {
 };
 
 export const Froglet: Story = {
-  render: () => (
+  render: (args) => (
     <div
       style={{
         display: "flex",
@@ -44,16 +53,20 @@ export const Froglet: Story = {
         maxWidth: "24rem",
       }}
     >
-      <Progress className="progress--primary" value={0.75} max={1} />
-      <Progress className="progress--secondary" value={0.5} max={1} />
-      <Progress className="progress--neutral" value={0.9} max={1} />
-      <Progress className="progress--danger" value={0.3} max={1} />
+      <Progress className="progress--primary" {...args} />
+      <Progress className="progress--secondary" {...args} />
+      <Progress className="progress--neutral" {...args} />
+      <Progress className="progress--danger" {...args} />
     </div>
   ),
+  args: {
+    value: 0.6,
+    max: 1,
+  },
   parameters: {
     docs: {
       description: {
-        story: `Four Froglet palette variants — primary, secondary, neutral, and danger — each using a modifier class that sets fill and track colors.
+        story: `Four Froglet palette variants — primary, secondary, neutral, and danger. Use the Controls panel \`value\` slider to scrub all four bars simultaneously.
 
 \`\`\`css
 .progress--primary {

--- a/apps/storybook/src/stories/Radio.stories.tsx
+++ b/apps/storybook/src/stories/Radio.stories.tsx
@@ -17,6 +17,11 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
 } satisfies Meta<typeof Radio>;
 
 export default meta;

--- a/apps/storybook/src/stories/Select.stories.tsx
+++ b/apps/storybook/src/stories/Select.stories.tsx
@@ -17,6 +17,11 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
 } satisfies Meta<typeof Select>;
 
 export default meta;

--- a/apps/storybook/src/stories/Table.stories.tsx
+++ b/apps/storybook/src/stories/Table.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Table } from "@froglet/ui";
+import type { TableColumn, TableProps } from "@froglet/ui";
+import "../assets/css/table.storybook.css";
+import readme from "../../../../packages/froglet-ui/src/Table/README.md?raw";
+
+// Strip the leading `# Table` heading — Storybook renders its own h1 from the story title.
+const readmeBody = readme.replace(/^#[^\n]*\n+/, "");
+
+// Sample data shared across stories.
+type Row = { name: string; role: string; status: string };
+
+const columns: TableColumn<Row>[] = [
+  { key: "name", label: "Name" },
+  { key: "role", label: "Role" },
+  { key: "status", label: "Status" },
+];
+
+const data: Row[] = [
+  { name: "Alice Martin", role: "Engineer", status: "Active" },
+  { name: "Bob Chen", role: "Designer", status: "Active" },
+  { name: "Carol Smith", role: "Manager", status: "On leave" },
+];
+
+// Cast to a concrete type so Storybook's Meta can resolve the generic.
+type ConcreteTable = React.ComponentType<TableProps<Row>>;
+
+const meta = {
+  title: "Table",
+  component: Table as ConcreteTable,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component: readmeBody,
+      },
+    },
+  },
+} satisfies Meta<ConcreteTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Table columns={columns} data={data} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The unstyled Froglet UI table. No CSS custom properties are set — renders with browser defaults. Apply a modifier class to theme it.",
+      },
+    },
+  },
+};
+
+export const Froglet: Story = {
+  render: () => (
+    <Table
+      className="table--froglet"
+      columns={columns}
+      data={data}
+      caption="Team members"
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: `Themed with the Froglet neutral palette. Header has a subtle background and 2px bottom border. Rows alternate between \`Canvas\` and a light gray stripe. A \`caption\` is provided for accessibility.
+
+\`\`\`css
+.table--froglet {
+  --table-th-background-color: #f9fafb;
+  --table-th-text-color: #111827;
+  --table-th-border-bottom-width: 2px;
+  --table-th-border-bottom-color: #d1d5db;
+  --table-tr-background-color-even: #f9fafb;
+  --table-tr-background-color-odd: #ffffff;
+  --table-td-text-color: #111827;
+  --table-td-border-bottom-width: 1px;
+  --table-td-border-bottom-color: #d1d5db;
+  --table-caption-text-color: #6b7280;
+}
+\`\`\``,
+      },
+    },
+  },
+};

--- a/apps/storybook/src/stories/Textarea.stories.tsx
+++ b/apps/storybook/src/stories/Textarea.stories.tsx
@@ -17,6 +17,11 @@ const meta = {
       },
     },
   },
+  argTypes: {
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
 } satisfies Meta<typeof Textarea>;
 
 export default meta;

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -428,6 +428,23 @@ All interactive components share a consistent shape language.
 }
 ```
 
+### Table
+
+```css
+.table--froglet {
+  --table-th-background-color: #f9fafb;
+  --table-th-text-color: #111827;
+  --table-th-border-bottom-width: 2px;
+  --table-th-border-bottom-color: #d1d5db;
+  --table-tr-background-color-even: #f9fafb;
+  --table-tr-background-color-odd: #ffffff;
+  --table-td-text-color: #111827;
+  --table-td-border-bottom-width: 1px;
+  --table-td-border-bottom-color: #d1d5db;
+  --table-caption-text-color: #6b7280;
+}
+```
+
 ### Switch
 
 ```css

--- a/packages/froglet-ui/src/Table/README.md
+++ b/packages/froglet-ui/src/Table/README.md
@@ -1,0 +1,131 @@
+# Table
+
+A brandless data table wrapping native `<table>`, `<thead>`, and `<tbody>` elements. Accepts typed column definitions and data rows. All visual styling is driven by CSS custom properties.
+
+## Usage
+
+```tsx
+import { Table } from "@froglet/ui";
+import type { TableColumn } from "@froglet/ui";
+
+type Row = { name: string; role: string; status: string };
+
+const columns: TableColumn<Row>[] = [
+  { key: "name", label: "Name" },
+  { key: "role", label: "Role" },
+  { key: "status", label: "Status" },
+];
+
+const data: Row[] = [
+  { name: "Alice Martin", role: "Engineer", status: "Active" },
+  { name: "Bob Chen", role: "Designer", status: "Active" },
+];
+
+function Example() {
+  return <Table columns={columns} data={data} caption="Team members" />;
+}
+```
+
+### Themed
+
+```tsx
+<Table
+  className="table--froglet"
+  columns={columns}
+  data={data}
+  caption="Team members"
+/>
+```
+
+### Custom cell render
+
+```tsx
+const columns: TableColumn<Row>[] = [
+  { key: "name", label: "Name" },
+  {
+    key: "status",
+    label: "Status",
+    render: (value) => <strong>{String(value)}</strong>,
+  },
+];
+```
+
+## Props
+
+### `TableProps<T>`
+
+| Prop        | Type                          | Default | Description                                         |
+| ----------- | ----------------------------- | ------- | --------------------------------------------------- |
+| `columns`   | `TableColumn<T>[]`            | —       | Column definitions. Order determines column order.  |
+| `data`      | `T[]`                         | —       | Data rows.                                          |
+| `caption`   | `string`                      | —       | Table caption. Recommended for screen readers.      |
+| `className` | `string`                      | —       | Additional CSS classes. Use to apply a token block. |
+| `ref`       | `React.Ref<HTMLTableElement>` | —       | Forwarded to the underlying `<table>` element.      |
+
+### `TableColumn<T>`
+
+| Prop     | Type                                             | Default | Description                                                |
+| -------- | ------------------------------------------------ | ------- | ---------------------------------------------------------- |
+| `key`    | `keyof T & string`                               | —       | Column key. Must match a property key of `T`.              |
+| `label`  | `string`                                         | `key`   | Column header text. Falls back to `key` if omitted.        |
+| `render` | `(value: T[keyof T], row: T) => React.ReactNode` | —       | Optional cell renderer. Defaults to `String(value ?? "")`. |
+
+## CSS Custom Properties
+
+| Token                              | Default        | Description                                      |
+| ---------------------------------- | -------------- | ------------------------------------------------ |
+| `--table-width`                    | `100%`         | Table width.                                     |
+| `--table-border-collapse`          | `collapse`     | Border collapse mode.                            |
+| `--table-font-size`                | `1rem`         | Base font size.                                  |
+| `--table-border-width`             | `0`            | Outer table border width.                        |
+| `--table-border-style`             | `solid`        | Shared border style (used by outer, th, and td). |
+| `--table-border-color`             | —              | Outer border color. No border when unset.        |
+| `--table-border-radius`            | `0`            | Outer border radius.                             |
+| `--table-background-color`         | —              | Table background.                                |
+| `--table-caption-font-size`        | `0.875rem`     | Caption font size.                               |
+| `--table-caption-text-color`       | —              | Caption text color.                              |
+| `--table-caption-padding-bottom`   | `0.5rem`       | Gap between caption and table.                   |
+| `--table-th-padding`               | `0.75rem 1rem` | Header cell padding.                             |
+| `--table-th-text-align`            | `left`         | Header cell alignment.                           |
+| `--table-th-font-weight`           | `600`          | Header cell font weight.                         |
+| `--table-th-background-color`      | —              | Header cell background.                          |
+| `--table-th-text-color`            | —              | Header cell text color.                          |
+| `--table-th-border-bottom-width`   | `2px`          | Header cell bottom border width.                 |
+| `--table-th-border-bottom-color`   | `currentColor` | Header cell bottom border color.                 |
+| `--table-tr-background-color-even` | —              | Even row background (striping).                  |
+| `--table-tr-background-color-odd`  | —              | Odd row background (striping).                   |
+| `--table-td-padding`               | `0.75rem 1rem` | Body cell padding.                               |
+| `--table-td-text-color`            | —              | Body cell text color.                            |
+| `--table-td-border-bottom-width`   | `1px`          | Body cell bottom border width.                   |
+| `--table-td-border-bottom-color`   | `currentColor` | Body cell bottom border color.                   |
+
+### Notes
+
+- `--table-border-style` is shared across outer border, header bottom border, and body cell bottom border.
+- Row striping uses `:nth-child(even)` and `:nth-child(odd)` on `.table__tr`. Both tokens are bare vars with no fallback, so no stripe is applied when unset.
+- To get outer `border-radius` working visually, set `--table-border-collapse: separate` alongside `border-spacing: 0` and `overflow: hidden` in your theme class.
+
+## Variants
+
+Apply a modifier class that sets CSS custom properties:
+
+```css
+.table--froglet {
+  --table-th-background-color: #f9fafb;
+  --table-th-text-color: #111827;
+  --table-th-border-bottom-width: 2px;
+  --table-th-border-bottom-color: #d1d5db;
+  --table-tr-background-color-even: #f9fafb;
+  --table-tr-background-color-odd: #ffffff;
+  --table-td-text-color: #111827;
+  --table-td-border-bottom-width: 1px;
+  --table-td-border-bottom-color: #d1d5db;
+  --table-caption-text-color: #6b7280;
+}
+```
+
+## Accessibility
+
+- `<caption>` provides a table title for screen readers. Strongly recommended when multiple tables are on the same page.
+- Each `<th>` has `scope="col"` so screen readers associate headers with their columns.
+- Row keys default to `rowIndex`. If your data has a stable unique identifier, consider passing it via a `render` function or wrapping the table to add `data-*` attributes.

--- a/packages/froglet-ui/src/Table/Table.test.tsx
+++ b/packages/froglet-ui/src/Table/Table.test.tsx
@@ -1,0 +1,39 @@
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Table } from "./Table";
+
+const columns = [
+  { key: "name" as const, label: "Name" },
+  { key: "role" as const, label: "Role" },
+];
+
+const data = [
+  { name: "Alice", role: "Engineer" },
+  { name: "Bob", role: "Designer" },
+];
+
+describe("Table", () => {
+  it("renders", () => {
+    render(<Table columns={columns} data={data} />);
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+
+  it("applies className", () => {
+    render(<Table columns={columns} data={data} className="table--froglet" />);
+    const el = screen.getByRole("table");
+    expect(el).toHaveClass("table");
+    expect(el).toHaveClass("table--froglet");
+  });
+
+  it("renders column headers", () => {
+    render(<Table columns={columns} data={data} />);
+    expect(screen.getAllByRole("columnheader")).toHaveLength(columns.length);
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLTableElement>();
+    render(<Table columns={columns} data={data} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTableElement);
+  });
+});

--- a/packages/froglet-ui/src/Table/Table.tsx
+++ b/packages/froglet-ui/src/Table/Table.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import classNames from "classnames";
+import "./table.css";
+
+export interface TableColumn<T extends Record<string, unknown>> {
+  /** Column key — must be a key of T. */
+  key: keyof T & string;
+  /** Display label for the column header. Falls back to `key` if omitted. */
+  label?: string;
+  /** Optional render function for cell content. Defaults to string coercion. */
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+}
+
+export interface TableProps<T extends Record<string, unknown>> {
+  /** Column definitions. Order determines column order. */
+  columns: TableColumn<T>[];
+  /** Data rows. */
+  data: T[];
+  /** Table caption for screen readers. Recommended for accessibility. */
+  caption?: string;
+  /** Additional CSS classes on `<table>`. Use to apply a token block. */
+  className?: string;
+  /** Forwarded to the `<table>` element. */
+  ref?: React.Ref<HTMLTableElement>;
+}
+
+/** A brandless data table. All visual styling is driven by CSS custom properties. */
+export const Table = <T extends Record<string, unknown>>({
+  columns,
+  data,
+  caption,
+  className,
+  ref,
+}: TableProps<T>) => {
+  return (
+    <table ref={ref} className={classNames("table", className)}>
+      {caption && <caption className="table__caption">{caption}</caption>}
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col.key} scope="col" className="table__th">
+              {col.label ?? col.key}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, rowIndex) => (
+          <tr key={rowIndex} className="table__tr">
+            {columns.map((col) => (
+              <td key={col.key} className="table__td">
+                {col.render
+                  ? col.render(row[col.key], row)
+                  : String(row[col.key] ?? "")}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/packages/froglet-ui/src/Table/index.ts
+++ b/packages/froglet-ui/src/Table/index.ts
@@ -1,0 +1,2 @@
+export { Table } from "./Table";
+export type { TableProps, TableColumn } from "./Table";

--- a/packages/froglet-ui/src/Table/table.css
+++ b/packages/froglet-ui/src/Table/table.css
@@ -1,0 +1,76 @@
+/*
+--------------------------------------------------------------------------------
+    Table CSS File
+    Represents CSS Custom Property Style for Table
+--------------------------------------------------------------------------------
+*/
+
+/* Base Table */
+.table {
+  /* Box Model */
+  box-sizing: border-box;
+  width: var(--table-width, 100%);
+  border-collapse: var(--table-border-collapse, collapse);
+  border-spacing: 0;
+  border-width: var(--table-border-width, 0);
+  border-style: var(--table-border-style, solid);
+  border-color: var(--table-border-color);
+  border-radius: var(--table-border-radius, 0);
+
+  /* Typography */
+  font-size: var(--table-font-size, 1rem);
+
+  /* Visual Styles */
+  background-color: var(--table-background-color);
+}
+
+/* Caption */
+.table__caption {
+  caption-side: top;
+  text-align: left;
+
+  /* Typography */
+  font-size: var(--table-caption-font-size, 0.875rem);
+
+  /* Visual Styles */
+  color: var(--table-caption-text-color);
+  padding-bottom: var(--table-caption-padding-bottom, 0.5rem);
+}
+
+/* Header cells */
+.table__th {
+  /* Box Model */
+  padding: var(--table-th-padding, 0.75rem 1rem);
+  border-bottom-width: var(--table-th-border-bottom-width, 2px);
+  border-bottom-style: var(--table-border-style, solid);
+  border-bottom-color: var(--table-th-border-bottom-color, currentColor);
+
+  /* Typography */
+  text-align: var(--table-th-text-align, left);
+  font-weight: var(--table-th-font-weight, 600);
+
+  /* Visual Styles */
+  background-color: var(--table-th-background-color);
+  color: var(--table-th-text-color);
+}
+
+/* Body rows — stripe */
+.table__tr:nth-child(even) {
+  background-color: var(--table-tr-background-color-even);
+}
+
+.table__tr:nth-child(odd) {
+  background-color: var(--table-tr-background-color-odd);
+}
+
+/* Body cells */
+.table__td {
+  /* Box Model */
+  padding: var(--table-td-padding, 0.75rem 1rem);
+  border-bottom-width: var(--table-td-border-bottom-width, 1px);
+  border-bottom-style: var(--table-border-style, solid);
+  border-bottom-color: var(--table-td-border-bottom-color, currentColor);
+
+  /* Visual Styles */
+  color: var(--table-td-text-color);
+}

--- a/packages/froglet-ui/src/index.ts
+++ b/packages/froglet-ui/src/index.ts
@@ -32,5 +32,7 @@ export { Select } from "./Select";
 export type { SelectProps } from "./Select";
 export { Switch } from "./Switch";
 export type { SwitchProps } from "./Switch";
+export { Table } from "./Table";
+export type { TableProps, TableColumn } from "./Table";
 export { Textarea } from "./Textarea";
 export type { TextareaProps } from "./Textarea";


### PR DESCRIPTION
# Pull Request

## Issue Description

- Add Table component: generic <table> wrapper, columns/data/caption props
- table.css: BEM classes, --table-* tokens, currentColor border defaults
- 4 tests, barrel, README, Storybook story + storybook CSS
- Export Table between Switch and Textarea in root index.ts
- Add Table section to docs/style-guide.md
- Storybook controls pass: add argTypes to Button, Radio, Select, Textarea, Divider
- Progress: add argTypes value range control, wire Froglet story to args
- Grid: add missing autoRows to argTypes, seed args in Default and Controls

## Testing Instructions

1. View Storybook `npm run dev`